### PR TITLE
Legacy API fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,7 @@ module.exports = (css, settings) => {
   const data = stripIndent(optionData) + '\n' + stripIndent(cssWithPlaceholders)
   const file = settings.babel && settings.babel.filename
 
-  const preprocessed = sass
-    .renderSync(Object.assign({}, { file }, settings.sassOptions, { data }))
-    .css.toString()
+  const preprocessed = sass.compileString(data, settings.sassOptions).css.toString();
 
   return preprocessed
     .replace(


### PR DESCRIPTION
Changed the legacy API entrypoint renderSync to compileString, since the legacy JS API is  deprecated and will be removed in Dart Sass 2.0.0. See the note [here](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/)